### PR TITLE
fixed logic for castling

### DIFF
--- a/server/game/board.py
+++ b/server/game/board.py
@@ -199,15 +199,14 @@ class Board:
 
         # check if a piece is in the way
         if from_y == 0:
-            if to_x == 2 and self.state[0][0] != -Piece.ROOK and self.state[0][1] != Piece.NONE and self.state[0][2] != Piece.NONE and self.state[0][3] != Piece.NONE and self.state[0][
-                    3] != -Piece.KING:
+            if to_x == 2 and (self.state[0][0] != -Piece.ROOK or self.state[0][1] != Piece.NONE or self.state[0][2] != Piece.NONE or self.state[0][3] != Piece.NONE or self.state[0][4] != -Piece.KING):
                 return False
-            if to_x == 6 and self.state[0][7] != -Piece.ROOK and self.state[0][6] != Piece.NONE and self.state[0][5] != Piece.NONE and self.state[0][4] != -Piece.KING:
+            if to_x == 6 and (self.state[0][7] != -Piece.ROOK or self.state[0][6] != Piece.NONE or self.state[0][5] != Piece.NONE or self.state[0][4] != -Piece.KING):
                 return False
         else:
-            if to_x == 2 and self.state[7][0] != Piece.ROOK and self.state[7][1] != Piece.NONE and self.state[7][2] != Piece.NONE and self.state[7][3] != Piece.NONE and self.state[7][3] != Piece.KING:
+            if to_x == 2 and (self.state[7][0] != Piece.ROOK or self.state[7][1] != Piece.NONE or self.state[7][2] != Piece.NONE or self.state[7][3] != Piece.NONE or self.state[7][4] != Piece.KING):
                 return False
-            if to_x == 6 and self.state[7][7] != Piece.ROOK and self.state[7][6] != Piece.NONE and self.state[7][5] != Piece.NONE and self.state[7][4] != Piece.KING:
+            if to_x == 6 and (self.state[7][7] != Piece.ROOK or self.state[7][6] != Piece.NONE or self.state[7][5] != Piece.NONE or self.state[7][4] != Piece.KING):
                 return False
 
         white_rook_0_moved = False

--- a/server/tests/game/pieces/king_test.py
+++ b/server/tests/game/pieces/king_test.py
@@ -193,3 +193,21 @@ def test_castle7():
     assert board.register_move(castle)
     assert board.state[7][2] == Piece.KING
     assert board.state[7][3] == Piece.ROOK
+
+
+def test_castle_piece_in_way():
+    board = get_empty_board()
+
+    king = Square(4, 7)
+    rook = Square(0, 7)
+    queen = Square(7, 0)
+    knight = Square(1, 7)
+
+    board.state[king.y][king.x] = Piece.KING
+    board.state[rook.y][rook.x] = Piece.ROOK
+    board.state[knight.y][knight.x] = Piece.KNIGHT
+    board.state[queen.y][queen.x] = -Piece.QUEEN
+
+    castle = Move(king, Square(2, 7))
+
+    assert not board.validate_move(castle)


### PR DESCRIPTION
castling now properly checks if pieces are in the way.

Note: I could not test the case on my local branch until PR #39 is implemented since it breaks my SQLAlchemy.

You can try to test this yourself to see if it fixes the infinite recursion or not. There might still be edge cases where I don't detect a proper castle early enough? or a valid castle loops infinitely.