### PR TITLE
Launch server without gunicorn

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -6,10 +6,6 @@ include .env
 start: $(VENV)/bin/activate
 	$(PYTHON_COMMAND) -m server
 
-.PHONY = prod
-prod: $(VENV)/bin/activate
-	gunicorn --worker-class eventlet -w 1 server:app -b 0.0.0.0:5555
-
 .PHONY = test
 test: $(VENV)/bin/activate
 	pytest -x -v

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --worker-class eventlet -w 1 server:app
+web: python -m server

--- a/server/server/__main__.py
+++ b/server/server/__main__.py
@@ -1,12 +1,15 @@
+import os
 from pbu import Logger
 from server.api.config import get_log_folder
 from .__init__ import socketio, app
 
 if __name__ == "__main__":
+    port = os.environ['PORT'] or "5555"
+
     logger = Logger("MAIN", log_folder=get_log_folder())
     logger.info("==========================================")
     logger.info("           Starting application")
     logger.info("==========================================")
 
     # start flask app
-    socketio.run(app, host="0.0.0.0", port="5555")
+    socketio.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
### Overview
* Tensorflow and eventlet/gevent don't work too well according to [source](https://github.com/benoitc/gunicorn/issues/2124)
* Given the time constraints I think we'll take the performance hit rather than missing the pvc feature all together