### PR TITLE
Fix production

### DIFF
--- a/server/rl_agent/agent.py
+++ b/server/rl_agent/agent.py
@@ -48,6 +48,9 @@ class RlAgent():
             self.train(100)
 
     def predict(self, board: Board) -> Move:
+        self.__agent = self.__build_agent()
+        self.__load_weights()
+
         actions = board.get_actions()
         predicted_move_index = self.__agent.forward(board.state)
         predicted_move = actions[predicted_move_index]


### PR DESCRIPTION
### Overview

#### Observation
- PVC failed when we ran the server using gunicorn with eventlet
- PVC works fine if we use `python -m server` 
  - Doing this in production means it'll take a hit in our performance

#### Solution
- Gunicorn uses threads that may not load the model intime for our predict, following [this suggestion](https://stackoverflow.com/questions/47115946/tensor-is-not-an-element-of-this-graph#answer-57698343), we should load the model everytime we call predict

Locally testing I did not find any slow down but further testing is needed