### PR TITLE
Fix leaderboard clearing local storage

### DIFF
--- a/client/src/services/leaderboard.ts
+++ b/client/src/services/leaderboard.ts
@@ -11,6 +11,9 @@ export async function getLeaderboard() {
         });
         return resp.data;
     } catch (err) {
-        console.error(err);
+        // Many errors are caused by bad token so clear it and refresh
+        localStorage.clear();
+        window.location.reload();
+        return null;
     }
 }


### PR DESCRIPTION
### Overview
* Navigating to the leaderboard page caused a reauth because it cleared the localStorage where we store our auth credentials